### PR TITLE
kernel::mem::slab: Improve the tests for Cache::allocate_object

### DIFF
--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -999,6 +999,7 @@ mod cache_allocate_object_test {
             verify_cache_invariants_v2(
                 &raw mut cache,
                 &name,
+                layout,
                 slab_man.allocated_addrs(),
                 &allocated_objects,
             );
@@ -1077,6 +1078,7 @@ mod cache_allocate_object_test {
             verify_cache_invariants_v2(
                 &raw mut cache,
                 &name,
+                layout,
                 slab_man.allocated_addrs(),
                 &slab_objects,
             );
@@ -1126,6 +1128,7 @@ mod cache_allocate_object_test {
             verify_cache_invariants_v2(
                 &raw mut cache,
                 &name,
+                layout,
                 slab_man.allocated_addrs(),
                 &slab_objects,
             );
@@ -1200,6 +1203,7 @@ mod cache_allocate_object_test {
             verify_cache_invariants_v2(
                 &raw mut cache,
                 &name,
+                layout,
                 slab_man.allocated_addrs(),
                 &slab_objects,
             );
@@ -1280,6 +1284,7 @@ mod cache_allocate_object_test {
             verify_cache_invariants_v2(
                 &raw mut cache,
                 &name,
+                layout,
                 slab_man.allocated_addrs(),
                 &slab_objects,
             );
@@ -1344,6 +1349,7 @@ mod cache_allocate_object_test {
             verify_cache_invariants_v2(
                 &raw mut cache,
                 &name,
+                layout,
                 slab_man.allocated_addrs(),
                 &slab_objects,
             );
@@ -1433,6 +1439,7 @@ mod cache_allocate_object_test {
             verify_cache_invariants_v2(
                 &raw mut cache,
                 &name,
+                layout,
                 slab_man.allocated_addrs(),
                 &slab_objects,
             );
@@ -1527,6 +1534,7 @@ mod cache_allocate_object_test {
             verify_cache_invariants_v2(
                 &raw mut cache,
                 &name,
+                layout,
                 slab_man.allocated_addrs(),
                 &slab_objects,
             );
@@ -1601,6 +1609,7 @@ mod cache_allocate_object_test {
             verify_cache_invariants_v2(
                 &raw mut cache,
                 &name,
+                layout,
                 slab_man.allocated_addrs(),
                 &slab_objects,
             );
@@ -1698,6 +1707,7 @@ mod cache_allocate_object_test {
             verify_cache_invariants_v2(
                 &raw mut cache,
                 &name,
+                layout,
                 slab_man.allocated_addrs(),
                 &slab_objects,
             );
@@ -1768,6 +1778,7 @@ mod cache_allocate_object_test {
             verify_cache_invariants_v2(
                 &raw mut cache,
                 &name,
+                layout,
                 slab_man.allocated_addrs(),
                 &slab_objects,
             );
@@ -3960,7 +3971,7 @@ mod test_utils {
     /// * `cache` must be a valid pointer.
     pub unsafe fn verify_cache_invariants<T: Default>(cache: *mut Cache<T>) {
         verify_cache_type(cache);
-        verify_cache_slab_layout(cache);
+        verify_cache_slab_layout(cache, (*cache).slab_layout);
         verify_cache_slabs_full(cache);
         verify_cache_slabs_partial(cache);
         verify_cache_slabs_empty(cache);
@@ -3975,13 +3986,14 @@ mod test_utils {
     pub unsafe fn verify_cache_invariants_v2<T: Default>(
         cache: *mut Cache<T>,
         name: &[char; CACHE_NAME_LENGTH],
+        layout: Layout,
         contained_slabs: &Vec<*mut u8>,
         allocated_objects: &Vec<SlabObject<T>>,
     ) {
         verify_cache_name(cache, name, "The cache name doesn't match the expected");
 
         verify_cache_type(cache);
-        verify_cache_slab_layout(cache);
+        verify_cache_slab_layout(cache, layout);
         verify_cache_slabs_full(cache);
         verify_cache_slabs_partial(cache);
         verify_cache_slabs_empty(cache);
@@ -4022,15 +4034,20 @@ mod test_utils {
     ///
     /// SAFETY:
     /// * `cache` must be a valid pointer.
-    unsafe fn verify_cache_slab_layout<T: Default>(cache: *mut Cache<T>) {
+    unsafe fn verify_cache_slab_layout<T: Default>(cache: *mut Cache<T>, expected_layout: Layout) {
+        assert_eq!(
+            expected_layout,
+            (*cache).slab_layout,
+            "The slab layout doesn't match the expected"
+        );
         assert!(
             Cache::<T>::min_slab_size() <= (*cache).slab_layout.size(),
-            "The size of `slab_layout` is too small"
+            "The size of the slab layout does not meet the min slab size requirement"
         );
         assert_eq!(
             0,
             (*cache).slab_layout.align() % align_of::<SlabHeader<T>>(),
-            "The alignment of `slab_layout` is incompatible with SlabHeader<T>"
+            "The alignment of the slab layout is incompatible with SlabHeader<T>"
         );
     }
 

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1110,6 +1110,7 @@ mod cache_allocate_object_test {
 
         let mut cache = Cache::<T>::new(['c'; CACHE_NAME_LENGTH], layout);
         let mut slab_man = SlabMan::<T>::new(layout);
+        let mut slab_objects = Vec::new();
 
         let empty_slab = slab_man.new_test_slab(&raw mut cache);
         cache.slabs_empty = empty_slab;
@@ -1136,7 +1137,16 @@ mod cache_allocate_object_test {
             "The slab_empty should be null after the allocation"
         );
 
-        unsafe { verify_cache_invariants(&raw mut cache) }
+        unsafe {
+            verify_cache_invariants(&raw mut cache);
+
+            slab_objects.push(allocated_object);
+            verify_allocated_objects_matched(
+                &raw mut cache,
+                &slab_objects,
+                "The cache should have the same objects allocated after the allocation",
+            );
+        }
     }
 
     #[test]
@@ -1149,6 +1159,7 @@ mod cache_allocate_object_test {
 
         let mut cache = Cache::<T>::new(['c'; CACHE_NAME_LENGTH], layout);
         let mut slab_man = SlabMan::<T>::new(layout);
+        let mut slab_objects = Vec::new();
 
         let empty_slab1 = slab_man.new_test_slab(&raw mut cache);
         let empty_slab2 = slab_man.new_test_slab(&raw mut cache);
@@ -1200,7 +1211,16 @@ mod cache_allocate_object_test {
             "The slabs_partial should contain the moved slab"
         );
 
-        unsafe { verify_cache_invariants(&raw mut cache) }
+        unsafe {
+            verify_cache_invariants(&raw mut cache);
+
+            slab_objects.push(allocated_object);
+            verify_allocated_objects_matched(
+                &raw mut cache,
+                &slab_objects,
+                "The cache should have the same objects allocated after the allocation",
+            );
+        }
     }
 
     #[test]
@@ -1271,7 +1291,16 @@ mod cache_allocate_object_test {
             "The partial_slab should be moved to the slabs_full list"
         );
 
-        unsafe { verify_cache_invariants(&raw mut cache) }
+        unsafe {
+            verify_cache_invariants(&raw mut cache);
+
+            slab_objects.push(allocated_object);
+            verify_allocated_objects_matched(
+                &raw mut cache,
+                &slab_objects,
+                "The cache should have the same objects allocated after the allocation",
+            );
+        }
     }
 
     #[test]
@@ -1326,7 +1355,16 @@ mod cache_allocate_object_test {
             "The partial_slab should be moved to the slabs_full list"
         );
 
-        unsafe { verify_cache_invariants(&raw mut cache) }
+        unsafe {
+            verify_cache_invariants(&raw mut cache);
+
+            slab_objects.push(allocated_object);
+            verify_allocated_objects_matched(
+                &raw mut cache,
+                &slab_objects,
+                "The cache should have the same objects allocated after the allocation",
+            );
+        }
     }
 
     #[test]
@@ -1406,7 +1444,16 @@ mod cache_allocate_object_test {
             "The slabs_full should have a single slab after the allocation"
         );
 
-        unsafe { verify_cache_invariants(&raw mut cache) }
+        unsafe {
+            verify_cache_invariants(&raw mut cache);
+
+            slab_objects.push(allocated_object);
+            verify_allocated_objects_matched(
+                &raw mut cache,
+                &slab_objects,
+                "The cache should have the same objects allocated after the allocation",
+            );
+        }
     }
 
     #[test]
@@ -1491,7 +1538,16 @@ mod cache_allocate_object_test {
             "The slabs_full should contain the full_slab"
         );
 
-        unsafe { verify_cache_invariants(&raw mut cache) }
+        unsafe {
+            verify_cache_invariants(&raw mut cache);
+
+            slab_objects.push(allocated_object);
+            verify_allocated_objects_matched(
+                &raw mut cache,
+                &slab_objects,
+                "The cache should have the same objects allocated after the allocation",
+            );
+        }
     }
 
     #[test]
@@ -1556,7 +1612,16 @@ mod cache_allocate_object_test {
             "The slabs_partial should contain both partial slabs after the allocation"
         );
 
-        unsafe { verify_cache_invariants(&raw mut cache) }
+        unsafe {
+            verify_cache_invariants(&raw mut cache);
+
+            slab_objects.push(allocated_object);
+            verify_allocated_objects_matched(
+                &raw mut cache,
+                &slab_objects,
+                "The cache should have the same objects allocated after the allocation",
+            );
+        }
     }
 
     #[test]
@@ -1644,7 +1709,16 @@ mod cache_allocate_object_test {
             "The slabs_full should contain the moved slab"
         );
 
-        unsafe { verify_cache_invariants(&raw mut cache) }
+        unsafe {
+            verify_cache_invariants(&raw mut cache);
+
+            slab_objects.push(allocated_object);
+            verify_allocated_objects_matched(
+                &raw mut cache,
+                &slab_objects,
+                "The cache should have the same objects allocated after the allocation",
+            );
+        }
     }
 
     #[test]
@@ -1703,7 +1777,18 @@ mod cache_allocate_object_test {
         assert!(result.is_ok(), "The result should be Ok but got {result:?}");
 
         // Assert
-        unsafe { verify_cache_invariants(&raw mut cache) }
+        let allocated_object = result.unwrap();
+
+        unsafe {
+            verify_cache_invariants(&raw mut cache);
+
+            slab_objects.push(allocated_object);
+            verify_allocated_objects_matched(
+                &raw mut cache,
+                &slab_objects,
+                "The cache should have the same objects allocated after the allocation",
+            );
+        }
     }
 }
 

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1153,6 +1153,11 @@ mod cache_allocate_object_test {
         }
         cache.slabs_empty = empty_slab1;
 
+        assert!(
+            unsafe { (*empty_slab1).total_slots > 1 },
+            "The empty slabs should have more than one free slot to ensure a partial slab after the allocation"
+        );
+
         assert_eq!(
             null_mut(),
             cache.slabs_partial,
@@ -1173,7 +1178,7 @@ mod cache_allocate_object_test {
         let moved_slab = allocated_object.source;
         assert!(
             unsafe { !SlabHeader::is_full(moved_slab) },
-            "The moved slab should not be full after the allocation to ensure it is moved to the slabs_partial"
+            "The moved slab should not be full after the allocation"
         );
         assert_eq!(
             1,

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -917,8 +917,8 @@ mod cache_allocate_object_test {
     extern crate alloc;
     use crate::mem::slab::Error::NoSlabAvailable;
     use crate::mem::slab::test_utils::{
-        SlabMan, TestObject, cache_allocated_addrs, contains_node, safe_slab_size, size_of_list,
-        verify_allocated_objects_matched, verify_cache_invariants, verify_contained_slabs_matched,
+        SlabMan, TestObject, contains_node, safe_slab_size, size_of_list,
+        verify_cache_invariants_v2,
     };
     use crate::mem::slab::{CACHE_NAME_LENGTH, Cache, SlabHeader};
     use alloc::vec::Vec;
@@ -1069,19 +1069,7 @@ mod cache_allocate_object_test {
         );
 
         unsafe {
-            verify_cache_invariants(&raw mut cache);
-
-            verify_contained_slabs_matched(
-                &raw mut cache,
-                slab_man.allocated_addrs(),
-                "The cache should contain the same slabs after the allocation",
-            );
-
-            verify_allocated_objects_matched(
-                &raw mut cache,
-                &slab_objects,
-                "The cache should have the same objects allocated after the allocation",
-            );
+            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
         }
     }
 
@@ -1122,21 +1110,9 @@ mod cache_allocate_object_test {
             "The slab_empty should be null after the allocation"
         );
 
+        slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants(&raw mut cache);
-
-            verify_contained_slabs_matched(
-                &raw mut cache,
-                slab_man.allocated_addrs(),
-                "The cache should contain the same slabs after the allocation",
-            );
-
-            slab_objects.push(allocated_object);
-            verify_allocated_objects_matched(
-                &raw mut cache,
-                &slab_objects,
-                "The cache should have the same objects allocated after the allocation",
-            );
+            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
         }
     }
 
@@ -1202,21 +1178,9 @@ mod cache_allocate_object_test {
             "The slabs_partial should contain the moved slab"
         );
 
+        slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants(&raw mut cache);
-
-            verify_contained_slabs_matched(
-                &raw mut cache,
-                slab_man.allocated_addrs(),
-                "The cache should contain the same slabs after the allocation",
-            );
-
-            slab_objects.push(allocated_object);
-            verify_allocated_objects_matched(
-                &raw mut cache,
-                &slab_objects,
-                "The cache should have the same objects allocated after the allocation",
-            );
+            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
         }
     }
 
@@ -1288,21 +1252,9 @@ mod cache_allocate_object_test {
             "The partial_slab should be moved to the slabs_full list"
         );
 
+        slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants(&raw mut cache);
-
-            verify_contained_slabs_matched(
-                &raw mut cache,
-                slab_man.allocated_addrs(),
-                "The cache should contain the same slabs after the allocation",
-            );
-
-            slab_objects.push(allocated_object);
-            verify_allocated_objects_matched(
-                &raw mut cache,
-                &slab_objects,
-                "The cache should have the same objects allocated after the allocation",
-            );
+            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
         }
     }
 
@@ -1358,21 +1310,9 @@ mod cache_allocate_object_test {
             "The partial_slab should be moved to the slabs_full list"
         );
 
+        slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants(&raw mut cache);
-
-            verify_contained_slabs_matched(
-                &raw mut cache,
-                slab_man.allocated_addrs(),
-                "The cache should contain the same slabs after the allocation",
-            );
-
-            slab_objects.push(allocated_object);
-            verify_allocated_objects_matched(
-                &raw mut cache,
-                &slab_objects,
-                "The cache should have the same objects allocated after the allocation",
-            );
+            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
         }
     }
 
@@ -1453,21 +1393,9 @@ mod cache_allocate_object_test {
             "The slabs_full should have a single slab after the allocation"
         );
 
+        slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants(&raw mut cache);
-
-            verify_contained_slabs_matched(
-                &raw mut cache,
-                slab_man.allocated_addrs(),
-                "The cache should contain the same slabs after the allocation",
-            );
-
-            slab_objects.push(allocated_object);
-            verify_allocated_objects_matched(
-                &raw mut cache,
-                &slab_objects,
-                "The cache should have the same objects allocated after the allocation",
-            );
+            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
         }
     }
 
@@ -1553,21 +1481,9 @@ mod cache_allocate_object_test {
             "The slabs_full should contain the full_slab"
         );
 
+        slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants(&raw mut cache);
-
-            verify_contained_slabs_matched(
-                &raw mut cache,
-                slab_man.allocated_addrs(),
-                "The cache should contain the same slabs after the allocation",
-            );
-
-            slab_objects.push(allocated_object);
-            verify_allocated_objects_matched(
-                &raw mut cache,
-                &slab_objects,
-                "The cache should have the same objects allocated after the allocation",
-            );
+            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
         }
     }
 
@@ -1633,21 +1549,9 @@ mod cache_allocate_object_test {
             "The slabs_partial should contain both partial slabs after the allocation"
         );
 
+        slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants(&raw mut cache);
-
-            verify_contained_slabs_matched(
-                &raw mut cache,
-                slab_man.allocated_addrs(),
-                "The cache should contain the same slabs after the allocation",
-            );
-
-            slab_objects.push(allocated_object);
-            verify_allocated_objects_matched(
-                &raw mut cache,
-                &slab_objects,
-                "The cache should have the same objects allocated after the allocation",
-            );
+            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
         }
     }
 
@@ -1736,21 +1640,9 @@ mod cache_allocate_object_test {
             "The slabs_full should contain the moved slab"
         );
 
+        slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants(&raw mut cache);
-
-            verify_contained_slabs_matched(
-                &raw mut cache,
-                slab_man.allocated_addrs(),
-                "The cache should contain the same slabs after the allocation",
-            );
-
-            slab_objects.push(allocated_object);
-            verify_allocated_objects_matched(
-                &raw mut cache,
-                &slab_objects,
-                "The cache should have the same objects allocated after the allocation",
-            );
+            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
         }
     }
 
@@ -1812,21 +1704,9 @@ mod cache_allocate_object_test {
         // Assert
         let allocated_object = result.unwrap();
 
+        slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants(&raw mut cache);
-
-            verify_contained_slabs_matched(
-                &raw mut cache,
-                slab_man.allocated_addrs(),
-                "The cache should contain the same slabs after the allocation",
-            );
-
-            slab_objects.push(allocated_object);
-            verify_allocated_objects_matched(
-                &raw mut cache,
-                &slab_objects,
-                "The cache should have the same objects allocated after the allocation",
-            );
+            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
         }
     }
 }
@@ -4022,6 +3902,35 @@ mod test_utils {
         verify_cache_slabs_empty(cache);
     }
 
+    /// Verify if the `cache` satisfies the invariants of a [Cache].
+    // todo!(list the checked variants)
+    // todo!(rename to verify_cache_invariants after the old function is removed)
+    ///
+    /// # SAFETY:
+    /// * `cache` must be a valid pointer.
+    pub unsafe fn verify_cache_invariants_v2<T: Default>(
+        cache: *mut Cache<T>,
+        contained_slabs: &Vec<*mut u8>,
+        allocated_objects: &Vec<SlabObject<T>>,
+    ) {
+        verify_cache_type(cache);
+        verify_cache_slab_layout(cache);
+        verify_cache_slabs_full(cache);
+        verify_cache_slabs_partial(cache);
+        verify_cache_slabs_empty(cache);
+
+        verify_contained_slabs(
+            cache,
+            contained_slabs,
+            "The contained slabs don't match the expected",
+        );
+        verify_allocated_objects(
+            cache,
+            allocated_objects,
+            "The allocated objects don't match the expected",
+        );
+    }
+
     /// Verify if the type [T] of `cache` satisfies the invariant of a [Cache].
     ///
     /// SAFETY:
@@ -4264,7 +4173,7 @@ mod test_utils {
         )
     }
 
-    pub unsafe fn verify_contained_slabs_matched<T: Default>(
+    pub unsafe fn verify_contained_slabs<T: Default>(
         cache: *mut Cache<T>,
         slabs: &Vec<*mut u8>,
         err_message: &str,
@@ -4281,7 +4190,7 @@ mod test_utils {
         assert_eq!(expected_addrs, actual_addrs, "{}", err_message,);
     }
 
-    pub unsafe fn verify_allocated_objects_matched<T: Default>(
+    pub unsafe fn verify_allocated_objects<T: Default>(
         cache: *mut Cache<T>,
         slab_objects: &Vec<SlabObject<T>>,
         err_message: &str,

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -932,14 +932,15 @@ mod cache_allocate_object_test {
     }
 
     #[test]
-    fn no_slabs_returns_no_slab_available_err() {
+    fn no_slabs_returns_no_slab_available_err_cache_unmodified() {
         // Arrange:
         // Create a cache with no slabs.
         type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
+        let name = ['c'; CACHE_NAME_LENGTH];
 
-        let mut cache = Cache::<T>::new(['c'; CACHE_NAME_LENGTH], layout);
+        let mut cache = Cache::<T>::new(name, layout);
 
         assert_eq!(
             null_mut(),
@@ -971,6 +972,30 @@ mod cache_allocate_object_test {
             matches!(err, NoSlabAvailable),
             "The error should be {:?} but got {err:?}",
             NoSlabAvailable,
+        );
+
+        assert_eq!(
+            name, cache.name,
+            "The name should remain unmodified after the allocation"
+        );
+        assert_eq!(
+            layout, cache.slab_layout,
+            "The slab_layout should remain unmodified after the allocation"
+        );
+        assert_eq!(
+            null_mut(),
+            cache.slabs_full,
+            "The slabs_full should remain null after the allocation"
+        );
+        assert_eq!(
+            null_mut(),
+            cache.slabs_partial,
+            "The slabs_partial should remain null after the allocation"
+        );
+        assert_eq!(
+            null_mut(),
+            cache.slabs_empty,
+            "The slabs_empty should remain null after the allocation"
         );
     }
 

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -942,6 +942,8 @@ mod cache_allocate_object_test {
         let name = ['c'; CACHE_NAME_LENGTH];
 
         let mut cache = Cache::<T>::new(name, layout);
+        let slab_man = SlabMan::<T>::new(layout);
+        let allocated_objects = Vec::new();
 
         assert_eq!(
             null_mut(),
@@ -976,28 +978,31 @@ mod cache_allocate_object_test {
         );
 
         assert_eq!(
-            name, cache.name,
-            "The name should remain unmodified after the allocation"
-        );
-        assert_eq!(
-            layout, cache.slab_layout,
-            "The slab_layout should remain unmodified after the allocation"
-        );
-        assert_eq!(
             null_mut(),
             cache.slabs_full,
             "The slabs_full should remain null after the allocation"
         );
+
         assert_eq!(
             null_mut(),
             cache.slabs_partial,
             "The slabs_partial should remain null after the allocation"
         );
+
         assert_eq!(
             null_mut(),
             cache.slabs_empty,
             "The slabs_empty should remain null after the allocation"
         );
+
+        unsafe {
+            verify_cache_invariants_v2(
+                &raw mut cache,
+                &name,
+                slab_man.allocated_addrs(),
+                &allocated_objects,
+            );
+        }
     }
 
     #[test]
@@ -1069,7 +1074,12 @@ mod cache_allocate_object_test {
         );
 
         unsafe {
-            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
+            verify_cache_invariants_v2(
+                &raw mut cache,
+                &name,
+                slab_man.allocated_addrs(),
+                &slab_objects,
+            );
         }
     }
 
@@ -1080,8 +1090,9 @@ mod cache_allocate_object_test {
         type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
+        let name = ['c'; CACHE_NAME_LENGTH];
 
-        let mut cache = Cache::<T>::new(['c'; CACHE_NAME_LENGTH], layout);
+        let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
         let mut slab_objects = Vec::new();
 
@@ -1112,7 +1123,12 @@ mod cache_allocate_object_test {
 
         slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
+            verify_cache_invariants_v2(
+                &raw mut cache,
+                &name,
+                slab_man.allocated_addrs(),
+                &slab_objects,
+            );
         }
     }
 
@@ -1123,8 +1139,9 @@ mod cache_allocate_object_test {
         type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
+        let name = ['c'; CACHE_NAME_LENGTH];
 
-        let mut cache = Cache::<T>::new(['c'; CACHE_NAME_LENGTH], layout);
+        let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
         let mut slab_objects = Vec::new();
 
@@ -1180,7 +1197,12 @@ mod cache_allocate_object_test {
 
         slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
+            verify_cache_invariants_v2(
+                &raw mut cache,
+                &name,
+                slab_man.allocated_addrs(),
+                &slab_objects,
+            );
         }
     }
 
@@ -1192,8 +1214,9 @@ mod cache_allocate_object_test {
         type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
+        let name = ['c'; CACHE_NAME_LENGTH];
 
-        let mut cache = Cache::<T>::new(['c'; CACHE_NAME_LENGTH], layout);
+        let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
         let mut slab_objects = Vec::new();
 
@@ -1254,7 +1277,12 @@ mod cache_allocate_object_test {
 
         slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
+            verify_cache_invariants_v2(
+                &raw mut cache,
+                &name,
+                slab_man.allocated_addrs(),
+                &slab_objects,
+            );
         }
     }
 
@@ -1265,8 +1293,9 @@ mod cache_allocate_object_test {
         type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
+        let name = ['c'; CACHE_NAME_LENGTH];
 
-        let mut cache = Cache::<T>::new(['c'; CACHE_NAME_LENGTH], layout);
+        let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
         let mut slab_objects = Vec::new();
 
@@ -1312,7 +1341,12 @@ mod cache_allocate_object_test {
 
         slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
+            verify_cache_invariants_v2(
+                &raw mut cache,
+                &name,
+                slab_man.allocated_addrs(),
+                &slab_objects,
+            );
         }
     }
 
@@ -1323,8 +1357,9 @@ mod cache_allocate_object_test {
         type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
+        let name = ['c'; CACHE_NAME_LENGTH];
 
-        let mut cache = Cache::<T>::new(['c'; CACHE_NAME_LENGTH], layout);
+        let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
         let mut slab_objects = Vec::new();
 
@@ -1395,7 +1430,12 @@ mod cache_allocate_object_test {
 
         slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
+            verify_cache_invariants_v2(
+                &raw mut cache,
+                &name,
+                slab_man.allocated_addrs(),
+                &slab_objects,
+            );
         }
     }
 
@@ -1407,8 +1447,9 @@ mod cache_allocate_object_test {
         type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(1), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
+        let name = ['c'; CACHE_NAME_LENGTH];
 
-        let mut cache = Cache::<T>::new(['c'; CACHE_NAME_LENGTH], layout);
+        let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
         let mut slab_objects = Vec::new();
 
@@ -1483,7 +1524,12 @@ mod cache_allocate_object_test {
 
         slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
+            verify_cache_invariants_v2(
+                &raw mut cache,
+                &name,
+                slab_man.allocated_addrs(),
+                &slab_objects,
+            );
         }
     }
 
@@ -1495,8 +1541,9 @@ mod cache_allocate_object_test {
         type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(4), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
+        let name = ['c'; CACHE_NAME_LENGTH];
 
-        let mut cache = Cache::<T>::new(['c'; CACHE_NAME_LENGTH], layout);
+        let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
         let mut slab_objects = Vec::new();
 
@@ -1551,7 +1598,12 @@ mod cache_allocate_object_test {
 
         slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
+            verify_cache_invariants_v2(
+                &raw mut cache,
+                &name,
+                slab_man.allocated_addrs(),
+                &slab_objects,
+            );
         }
     }
 
@@ -1563,8 +1615,9 @@ mod cache_allocate_object_test {
         type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
+        let name = ['c'; CACHE_NAME_LENGTH];
 
-        let mut cache = Cache::<T>::new(['c'; CACHE_NAME_LENGTH], layout);
+        let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
         let mut slab_objects = Vec::new();
 
@@ -1642,7 +1695,12 @@ mod cache_allocate_object_test {
 
         slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
+            verify_cache_invariants_v2(
+                &raw mut cache,
+                &name,
+                slab_man.allocated_addrs(),
+                &slab_objects,
+            );
         }
     }
 
@@ -1653,8 +1711,9 @@ mod cache_allocate_object_test {
         type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(4), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
+        let name = ['c'; CACHE_NAME_LENGTH];
 
-        let mut cache = Cache::<T>::new(['c'; CACHE_NAME_LENGTH], layout);
+        let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
         let mut slab_objects = Vec::new();
 
@@ -1706,7 +1765,12 @@ mod cache_allocate_object_test {
 
         slab_objects.push(allocated_object);
         unsafe {
-            verify_cache_invariants_v2(&raw mut cache, slab_man.allocated_addrs(), &slab_objects);
+            verify_cache_invariants_v2(
+                &raw mut cache,
+                &name,
+                slab_man.allocated_addrs(),
+                &slab_objects,
+            );
         }
     }
 }
@@ -3910,9 +3974,12 @@ mod test_utils {
     /// * `cache` must be a valid pointer.
     pub unsafe fn verify_cache_invariants_v2<T: Default>(
         cache: *mut Cache<T>,
+        name: &[char; CACHE_NAME_LENGTH],
         contained_slabs: &Vec<*mut u8>,
         allocated_objects: &Vec<SlabObject<T>>,
     ) {
+        verify_cache_name(cache, name, "The cache name doesn't match the expected");
+
         verify_cache_type(cache);
         verify_cache_slab_layout(cache);
         verify_cache_slabs_full(cache);
@@ -3929,6 +3996,18 @@ mod test_utils {
             allocated_objects,
             "The allocated objects don't match the expected",
         );
+    }
+
+    /// Verify if the `cache` has the expected `name`.
+    ///
+    /// # Safety:
+    /// * `cache` must be a valid pointer.
+    pub unsafe fn verify_cache_name<T: Default>(
+        cache: *mut Cache<T>,
+        name: &[char; CACHE_NAME_LENGTH],
+        err_message: &str,
+    ) {
+        assert_eq!(name, &(*cache).name, "{}", err_message);
     }
 
     /// Verify if the type [T] of `cache` satisfies the invariant of a [Cache].

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -3980,34 +3980,34 @@ mod test_utils {
     }
 
     /// Verify if the `cache` satisfies the invariants of a [Cache].
-    // todo!(list the checked variants)
+    // todo!(list the checked invariants)
     // todo!(rename to verify_cache_invariants after the old function is removed)
     ///
     /// # SAFETY:
     /// * `cache` must be a valid pointer.
     pub unsafe fn verify_cache_invariants_v2<T: Default>(
         cache: *mut Cache<T>,
-        name: &[char; CACHE_NAME_LENGTH],
-        layout: Layout,
-        contained_slabs: &Vec<*mut u8>,
-        allocated_objects: &Vec<SlabObject<T>>,
+        expected_name: &[char; CACHE_NAME_LENGTH],
+        expected_layout: Layout,
+        expected_slabs: &Vec<*mut u8>,
+        expected_objects: &Vec<SlabObject<T>>,
     ) {
-        verify_cache_name(cache, name, "The cache name doesn't match the expected");
+        verify_cache_name(cache, expected_name, "The cache name doesn't match the expected");
 
         verify_cache_type(cache);
-        verify_cache_slab_layout(cache, layout);
+        verify_cache_slab_layout(cache, expected_layout);
         verify_cache_slabs_full(cache);
         verify_cache_slabs_partial(cache);
         verify_cache_slabs_empty(cache);
 
         verify_contained_slabs(
             cache,
-            contained_slabs,
+            expected_slabs,
             "The contained slabs don't match the expected",
         );
         verify_allocated_objects(
             cache,
-            allocated_objects,
+            expected_objects,
             "The allocated objects don't match the expected",
         );
     }
@@ -4273,10 +4273,10 @@ mod test_utils {
 
     pub unsafe fn verify_contained_slabs<T: Default>(
         cache: *mut Cache<T>,
-        slabs: &Vec<*mut u8>,
+        expected_slabs: &Vec<*mut u8>,
         err_message: &str,
     ) {
-        let mut expected_addrs = slabs.iter().map(|&slab| slab.addr()).collect::<Vec<_>>();
+        let mut expected_addrs = expected_slabs.iter().map(|&slab| slab.addr()).collect::<Vec<_>>();
         expected_addrs.sort();
 
         let mut actual_addrs = cache_slabs::<T>(cache)
@@ -4290,10 +4290,10 @@ mod test_utils {
 
     pub unsafe fn verify_allocated_objects<T: Default>(
         cache: *mut Cache<T>,
-        slab_objects: &Vec<SlabObject<T>>,
+        expected_objects: &Vec<SlabObject<T>>,
         err_message: &str,
     ) {
-        let mut expected_addrs = slab_objects
+        let mut expected_addrs = expected_objects
             .iter()
             .map(|slab_object| slab_object.object.addr())
             .collect::<Vec<_>>();

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -947,8 +947,8 @@ mod cache_allocate_object_test {
 
         assert_eq!(
             null_mut(),
-            cache.slabs_empty,
-            "The slabs_empty should be null initially"
+            cache.slabs_full,
+            "The slabs_full should be null initially"
         );
         assert_eq!(
             null_mut(),
@@ -957,8 +957,8 @@ mod cache_allocate_object_test {
         );
         assert_eq!(
             null_mut(),
-            cache.slabs_full,
-            "The slabs_full should be null initially"
+            cache.slabs_empty,
+            "The slabs_empty should be null initially"
         );
 
         // Act
@@ -982,13 +982,11 @@ mod cache_allocate_object_test {
             cache.slabs_full,
             "The slabs_full should remain null after the allocation"
         );
-
         assert_eq!(
             null_mut(),
             cache.slabs_partial,
             "The slabs_partial should remain null after the allocation"
         );
-
         assert_eq!(
             null_mut(),
             cache.slabs_empty,
@@ -1021,7 +1019,6 @@ mod cache_allocate_object_test {
 
         let full_slab1 = slab_man.new_test_slab(&raw mut cache);
         let full_slab2 = slab_man.new_test_slab(&raw mut cache);
-
         unsafe {
             // Fill each slab to make it full
             for slab in [full_slab1, full_slab2] {
@@ -1038,13 +1035,13 @@ mod cache_allocate_object_test {
 
         assert_eq!(
             null_mut(),
-            cache.slabs_empty,
-            "The slabs_empty should be null initially"
+            cache.slabs_partial,
+            "The slabs_partial should be null initially"
         );
         assert_eq!(
             null_mut(),
-            cache.slabs_partial,
-            "The slabs_partial should be null initially"
+            cache.slabs_empty,
+            "The slabs_empty should be null initially"
         );
 
         // Act
@@ -1176,7 +1173,7 @@ mod cache_allocate_object_test {
         let moved_slab = allocated_object.source;
         assert!(
             unsafe { !SlabHeader::is_full(moved_slab) },
-            "The moved slab should not be full"
+            "The moved slab should not be full after the allocation to ensure it is moved to the slabs_partial"
         );
         assert_eq!(
             1,
@@ -1195,7 +1192,7 @@ mod cache_allocate_object_test {
         );
         assert!(
             unsafe { contains_node(cache.slabs_partial, moved_slab) },
-            "The slabs_partial should contain the moved slab"
+            "The slabs_partial should contain the moved slab after the allocation"
         );
 
         slab_objects.push(allocated_object);
@@ -1526,7 +1523,7 @@ mod cache_allocate_object_test {
         );
         assert!(
             unsafe { contains_node(cache.slabs_full, full_slab) },
-            "The slabs_full should contain the full_slab"
+            "The slabs_full should contain the full_slab after the allocation"
         );
 
         slab_objects.push(allocated_object);


### PR DESCRIPTION
In #11, we supplemented tests to Cache::allocate_object, and this PR improves those tests in the following aspects:
- Verify the cache remains unmodified if an error is returned.
- Verify the cache contains the expected slabs after the allocation.
- Verify the cache has the expected objects allocated after the allocation.
- Verify the name of the cache remains unmodified after the allocation.
- Verify the slab_layout of the cache remains unmodified after the allocation.

In order to limit the scope of change, we introduce a new test utility verify_cache_invariants_v2 instead of refactoring the existing one. The verify_cache_invariants_v2 will gradually replace the verify_cache_invariants as the review goes on, and eventually be renamed to get rid of the v2.