### PR TITLE
kernel::mem::slab: Improve the tests for Cache::allocate_object

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="StructuralWrap" enabled="false" level="TYPO" enabled_by_default="false" />
+  </profile>
+</component>

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -994,13 +994,12 @@ mod cache_allocate_object_test {
 
     use crate::mem::slab::Error::NoSlabAvailable;
     use crate::mem::slab::test_utils::{
-        SlabMan, TestObject, TestObject2, prepend_new_slabs, safe_slab_layout, safe_slab_size,
+        SlabMan, TestObject, TestObject2, prepend_new_slabs, safe_slab_layout,
         verify_cache_invariants_v2,
     };
     use crate::mem::slab::{CACHE_NAME_LENGTH, Cache, SlabHeader};
     use alloc::vec;
     use alloc::vec::Vec;
-    use core::alloc::Layout;
     use core::fmt::Debug;
     use core::ptr::null_mut;
 

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -923,6 +923,7 @@ mod cache_allocate_object_test {
     use crate::mem::slab::{CACHE_NAME_LENGTH, Cache, SlabHeader};
     use alloc::vec::Vec;
     use core::alloc::Layout;
+    use core::fmt::Debug;
     use core::ptr::null_mut;
 
     type Type1 = TestObject;
@@ -934,6 +935,18 @@ mod cache_allocate_object_test {
             $(
                 #[test]
                 #[should_panic(expected = $panic_msg)]
+                fn $fn_name() {
+                    $test::<$t>()
+                }
+
+            )+
+        };
+    }
+
+    macro_rules! test_against_types {
+        ($test:ident, $(($fn_name:tt, $t:ty)), +,) => {
+            $(
+                #[test]
                 fn $fn_name() {
                     $test::<$t>()
                 }
@@ -954,11 +967,9 @@ mod cache_allocate_object_test {
         (null_cache_panics_for_type3, Type3),
     );
 
-    #[test]
-    fn no_slabs_returns_no_slab_available_err_cache_unmodified() {
+    fn test_no_slabs_returns_no_slab_available_err_cache_unmodified<T: Default + Debug>() {
         // Arrange:
         // Create a cache with no slabs.
-        type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
@@ -1025,6 +1036,22 @@ mod cache_allocate_object_test {
             );
         }
     }
+
+    test_against_types!(
+        test_no_slabs_returns_no_slab_available_err_cache_unmodified,
+        (
+            no_slabs_returns_no_slab_available_err_cache_unmodified_for_type1,
+            Type1
+        ),
+        (
+            no_slabs_returns_no_slab_available_err_cache_unmodified_for_type2,
+            Type2
+        ),
+        (
+            no_slabs_returns_no_slab_available_err_cache_unmodified_for_type3,
+            Type3
+        ),
+    );
 
     #[test]
     fn full_slabs_only_returns_no_slab_available_err_cache_unmodified() {

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -917,7 +917,7 @@ mod cache_allocate_object_test {
     extern crate alloc;
     use crate::mem::slab::Error::NoSlabAvailable;
     use crate::mem::slab::test_utils::{
-        SlabMan, TestObject, contains_node, safe_slab_size, size_of_list,
+        SlabMan, TestObject, TestObject2, contains_node, safe_slab_size, size_of_list,
         verify_cache_invariants_v2,
     };
     use crate::mem::slab::{CACHE_NAME_LENGTH, Cache, SlabHeader};
@@ -925,12 +925,34 @@ mod cache_allocate_object_test {
     use core::alloc::Layout;
     use core::ptr::null_mut;
 
-    #[test]
-    #[should_panic(expected = "Cache::allocate_object: cache should not be null")]
-    fn null_cache_panics() {
-        type T = TestObject;
+    type Type1 = TestObject;
+    type Type2 = TestObject2;
+    type Type3 = u8;
+
+    macro_rules! test_panic_against_types {
+        ($test:ident, $panic_msg:literal, $(($fn_name:tt, $t:ty)), +,) => {
+            $(
+                #[test]
+                #[should_panic(expected = $panic_msg)]
+                fn $fn_name() {
+                    $test::<$t>()
+                }
+
+            )+
+        };
+    }
+
+    fn test_null_cache_panics<T: Default>() {
         let _ = unsafe { Cache::<T>::allocate_object(null_mut()) };
     }
+
+    test_panic_against_types!(
+        test_null_cache_panics,
+        "Cache::allocate_object: cache should not be null",
+        (null_cache_panics_for_type1, Type1),
+        (null_cache_panics_for_type2, Type2),
+        (null_cache_panics_for_type3, Type3),
+    );
 
     #[test]
     fn no_slabs_returns_no_slab_available_err_cache_unmodified() {

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1251,9 +1251,8 @@ mod cache_allocate_object_test {
     fn test_returned_object_has_default_value_for_partial<T: Default + Debug + PartialEq>() {
         // Arrange:
         // Create a cache that contains a single partial slab.
-        let layout = Layout::from_size_align(safe_slab_size::<T>(4), align_of::<SlabHeader<T>>())
-            .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
+        let layout = safe_slab_layout::<T>(4);
 
         let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
@@ -1332,7 +1331,7 @@ mod cache_allocate_object_test {
         // Assert
         assert_eq!(
             empty_slab, allocated_object.source,
-            "The allocated object should come from the empty_slab"
+            "The allocated object should come from the empty slab"
         );
     }
 
@@ -1346,9 +1345,8 @@ mod cache_allocate_object_test {
     fn test_returned_object_has_correct_source_for_partial<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains one partial slab and two full slabs.
-        let layout = Layout::from_size_align(safe_slab_size::<T>(4), align_of::<SlabHeader<T>>())
-            .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
+        let layout = safe_slab_layout::<T>(4);
 
         let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
@@ -1380,7 +1378,7 @@ mod cache_allocate_object_test {
         // Assert
         assert_eq!(
             partial_slab, allocated_object.source,
-            "The allocated object should come from the partial_slab"
+            "The allocated object should come from the partial slab"
         );
     }
 
@@ -1764,8 +1762,8 @@ mod cache_allocate_object_test {
 
     fn test_partial_slab_remains_partial<T: Default + Debug>() {
         // Arrange:
-        // Create a cache that contains two partial slabs.
-        // Both partial slabs have more than one available slot.
+        // Create a cache that contains two partial slabs. Both partial slabs have more than one
+        // available slot.
         let name = ['c'; CACHE_NAME_LENGTH];
         let layout = safe_slab_layout::<T>(4);
 
@@ -1828,8 +1826,8 @@ mod cache_allocate_object_test {
 
     fn test_partial_slab_becomes_full<T: Default + Debug>() {
         // Arrange:
-        // Create a cache that contains two partial slabs and one full slab.
-        // Both partial slabs have only one slot available.
+        // Create a cache that contains two partial slabs and one full slab. Both partial slabs
+        // have only one slot available.
         let name = ['c'; CACHE_NAME_LENGTH];
         let layout = safe_slab_layout::<T>(2);
 

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1145,11 +1145,9 @@ mod cache_allocate_object_test {
         ),
     );
 
-    #[test]
-    fn slabs_empty_becomes_null_slabs_empty_is_null() {
+    fn test_slabs_empty_becomes_null_slabs_empty_is_null<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains a single empty slab.
-        type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
@@ -1194,6 +1192,22 @@ mod cache_allocate_object_test {
             );
         }
     }
+
+    test_against_types!(
+        test_slabs_empty_becomes_null_slabs_empty_is_null,
+        (
+            slabs_empty_becomes_null_slabs_empty_is_null_for_type1,
+            Type1
+        ),
+        (
+            slabs_empty_becomes_null_slabs_empty_is_null_for_type2,
+            Type2
+        ),
+        (
+            slabs_empty_becomes_null_slabs_empty_is_null_for_type3,
+            Type3
+        ),
+    );
 
     #[test]
     fn slabs_partial_becomes_non_null_slabs_partial_is_non_null() {

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1170,7 +1170,7 @@ mod cache_allocate_object_test {
         ),
     );
 
-    fn test_allocation_returned_object_has_default_value<T: Default + Debug + PartialEq>() {
+    fn test_returned_object_has_default_value<T: Default + Debug + PartialEq>() {
         // Arrange:
         // Create a cache that contains a single empty slab.
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
@@ -1212,22 +1212,13 @@ mod cache_allocate_object_test {
     }
 
     test_against_types!(
-        test_allocation_returned_object_has_default_value,
-        (
-            allocation_returned_object_has_default_value_for_type1,
-            Type1
-        ),
-        (
-            allocation_returned_object_has_default_value_for_type2,
-            Type2
-        ),
-        (
-            allocation_returned_object_has_default_value_for_type3,
-            Type3
-        ),
+        test_returned_object_has_default_value,
+        (returned_object_has_default_value_for_type1, Type1),
+        (returned_object_has_default_value_for_type2, Type2),
+        (returned_object_has_default_value_for_type3, Type3),
     );
 
-    fn test_slabs_empty_becomes_null_slabs_empty_is_null<T: Default + Debug>() {
+    fn test_slabs_empty_becomes_null<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains a single empty slab.
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
@@ -1285,22 +1276,13 @@ mod cache_allocate_object_test {
     }
 
     test_against_types!(
-        test_slabs_empty_becomes_null_slabs_empty_is_null,
-        (
-            slabs_empty_becomes_null_slabs_empty_is_null_for_type1,
-            Type1
-        ),
-        (
-            slabs_empty_becomes_null_slabs_empty_is_null_for_type2,
-            Type2
-        ),
-        (
-            slabs_empty_becomes_null_slabs_empty_is_null_for_type3,
-            Type3
-        ),
+        test_slabs_empty_becomes_null,
+        (slabs_empty_becomes_null_for_type1, Type1),
+        (slabs_empty_becomes_null_for_type2, Type2),
+        (slabs_empty_becomes_null_for_type3, Type3),
     );
 
-    fn test_slabs_partial_becomes_non_null_slabs_partial_is_non_null<T: Default + Debug>() {
+    fn test_slabs_partial_becomes_non_null<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains two empty slabs.
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
@@ -1384,22 +1366,13 @@ mod cache_allocate_object_test {
     }
 
     test_against_types!(
-        test_slabs_partial_becomes_non_null_slabs_partial_is_non_null,
-        (
-            slabs_partial_becomes_non_null_slabs_partial_is_non_null_for_type1,
-            Type1
-        ),
-        (
-            slabs_partial_becomes_non_null_slabs_partial_is_non_null_for_type2,
-            Type2
-        ),
-        (
-            slabs_partial_becomes_non_null_slabs_partial_is_non_null_for_type3,
-            Type3
-        ),
+        test_slabs_partial_becomes_non_null,
+        (slabs_partial_becomes_non_null_for_type1, Type1),
+        (slabs_partial_becomes_non_null_for_type2, Type2),
+        (slabs_partial_becomes_non_null_for_type3, Type3),
     );
 
-    fn test_slabs_partial_becomes_null_slabs_partial_is_null<T: Default + Debug>() {
+    fn test_slabs_partial_becomes_null<T: Default + Debug>() {
         // Arrange:
         // create a cache that contains a partial slab that is one free slot left and
         // a full slab.
@@ -1471,22 +1444,13 @@ mod cache_allocate_object_test {
     }
 
     test_against_types!(
-        test_slabs_partial_becomes_null_slabs_partial_is_null,
-        (
-            slabs_partial_becomes_null_slabs_partial_is_null_for_type1,
-            Type1
-        ),
-        (
-            slabs_partial_becomes_null_slabs_partial_is_null_for_type2,
-            Type2
-        ),
-        (
-            slabs_partial_becomes_null_slabs_partial_is_null_for_type3,
-            Type3
-        ),
+        test_slabs_partial_becomes_null,
+        (slabs_partial_becomes_null_for_type1, Type1),
+        (slabs_partial_becomes_null_for_type2, Type2),
+        (slabs_partial_becomes_null_for_type3, Type3),
     );
 
-    fn test_slabs_full_becomes_non_null_slabs_full_is_non_null<T: Default + Debug>() {
+    fn test_slabs_full_becomes_non_null<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains a partial slab that is one free slot left.
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
@@ -1552,22 +1516,13 @@ mod cache_allocate_object_test {
     }
 
     test_against_types!(
-        test_slabs_full_becomes_non_null_slabs_full_is_non_null,
-        (
-            slabs_full_becomes_non_null_slabs_full_is_non_null_for_type1,
-            Type1
-        ),
-        (
-            slabs_full_becomes_non_null_slabs_full_is_non_null_for_type2,
-            Type2
-        ),
-        (
-            slabs_full_becomes_non_null_slabs_full_is_non_null_for_type3,
-            Type3
-        ),
+        test_slabs_full_becomes_non_null,
+        (slabs_full_becomes_non_null_for_type1, Type1),
+        (slabs_full_becomes_non_null_for_type2, Type2),
+        (slabs_full_becomes_non_null_for_type3, Type3),
     );
 
-    fn test_an_empty_slab_becomes_partial_moves_correctly<T: Default + Debug>() {
+    fn test_empty_slab_becomes_partial<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains two empty slabs and a full slab.
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
@@ -1651,22 +1606,13 @@ mod cache_allocate_object_test {
     }
 
     test_against_types!(
-        test_an_empty_slab_becomes_partial_moves_correctly,
-        (
-            an_empty_slab_becomes_partial_moves_correctly_for_type1,
-            Type1
-        ),
-        (
-            an_empty_slab_becomes_partial_moves_correctly_for_type2,
-            Type2
-        ),
-        (
-            an_empty_slab_becomes_partial_moves_correctly_for_type3,
-            Type3
-        ),
+        test_empty_slab_becomes_partial,
+        (empty_slab_becomes_partial_for_type1, Type1),
+        (empty_slab_becomes_partial_for_type2, Type2),
+        (empty_slab_becomes_partial_for_type3, Type3),
     );
 
-    fn test_an_empty_slab_becomes_full_moves_correctly<T: Default + Debug>() {
+    fn test_empty_slab_becomes_full<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains two empty slabs and a full slab.
         // All slabs have a total_slots of one.
@@ -1756,12 +1702,12 @@ mod cache_allocate_object_test {
     }
 
     test_against_types!(
-        test_an_empty_slab_becomes_full_moves_correctly,
-        (an_empty_slab_becomes_full_moves_correctly_for_type1, Type1),
-        (an_empty_slab_becomes_full_moves_correctly_for_type2, Type2),
+        test_empty_slab_becomes_full,
+        (empty_slab_becomes_full_for_type1, Type1),
+        (empty_slab_becomes_full_for_type2, Type2),
     );
 
-    fn test_a_partial_slab_remains_partial_no_move<T: Default + Debug>() {
+    fn test_partial_slab_remains_partial<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains two partial slabs.
         // Both partial slabs have more than one available slot.
@@ -1832,13 +1778,13 @@ mod cache_allocate_object_test {
     }
 
     test_against_types!(
-        test_a_partial_slab_remains_partial_no_move,
-        (a_partial_slab_remains_partial_no_move_for_type1, Type1),
-        (a_partial_slab_remains_partial_no_move_for_type2, Type2),
-        (a_partial_slab_remains_partial_no_move_for_type3, Type3),
+        test_partial_slab_remains_partial,
+        (partial_slab_remains_partial_for_type1, Type1),
+        (partial_slab_remains_partial_for_type2, Type2),
+        (partial_slab_remains_partial_for_type3, Type3),
     );
 
-    fn test_a_partial_slab_becomes_full_moves_correctly<T: Default + Debug>() {
+    fn test_partial_slab_becomes_full<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains two partial slabs and one full slab.
         // Both partial slabs have only one slot available.
@@ -1922,13 +1868,13 @@ mod cache_allocate_object_test {
     }
 
     test_against_types!(
-        test_a_partial_slab_becomes_full_moves_correctly,
-        (a_partial_slab_becomes_full_moves_correctly_for_type1, Type1),
-        (a_partial_slab_becomes_full_moves_correctly_for_type2, Type2),
-        (a_partial_slab_becomes_full_moves_correctly_for_type3, Type3),
+        test_partial_slab_becomes_full,
+        (partial_slab_becomes_full_for_type1, Type1),
+        (partial_slab_becomes_full_for_type2, Type2),
+        (partial_slab_becomes_full_for_type3, Type3),
     );
 
-    fn test_general_case_holds_cache_invariants<T: Default + Debug>() {
+    fn test_general_case<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains three empty slabs, three partial slabs and two full slabs.
         type T = TestObject;
@@ -1971,10 +1917,10 @@ mod cache_allocate_object_test {
     }
 
     test_against_types!(
-        test_general_case_holds_cache_invariants,
-        (general_case_holds_cache_invariants_for_type1, Type1),
-        (general_case_holds_cache_invariants_for_type2, Type2),
-        (general_case_holds_cache_invariants_for_type3, Type3),
+        test_general_case,
+        (general_case_for_type1, Type1),
+        (general_case_for_type2, Type2),
+        (general_case_for_type3, Type3),
     );
 }
 

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -3819,6 +3819,27 @@ mod test_utils {
         }
     }
 
+    #[derive(Debug, PartialEq)]
+    pub struct TestObject2 {
+        x: TestObject,
+        y: TestObject,
+        z: u128,
+    }
+
+    impl Default for TestObject2 {
+        fn default() -> Self {
+            Self {
+                x: TestObject::default(),
+                y: TestObject {
+                    x: 121,
+                    y: 222,
+                    z: 306,
+                },
+                z: 9124,
+            }
+        }
+    }
+
     /// Calls `alloc` with the `layout` `count` times and
     /// returns a collection of the returned pointers.
     pub fn acquire_memory(layout: Layout, count: usize) -> Vec<*mut u8> {

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1680,12 +1680,10 @@ mod cache_allocate_object_test {
         (an_empty_slab_becomes_full_moves_correctly_for_type2, Type2),
     );
 
-    #[test]
-    fn a_partial_slab_remains_partial_no_move() {
+    fn test_a_partial_slab_remains_partial_no_move<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains two partial slabs.
         // Both partial slabs have more than one available slot.
-        type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(4), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
@@ -1754,6 +1752,13 @@ mod cache_allocate_object_test {
             );
         }
     }
+
+    test_against_types!(
+        test_a_partial_slab_remains_partial_no_move,
+        (a_partial_slab_remains_partial_no_move_for_type1, Type1),
+        (a_partial_slab_remains_partial_no_move_for_type2, Type2),
+        (a_partial_slab_remains_partial_no_move_for_type3, Type3),
+    );
 
     #[test]
     fn a_partial_slab_becomes_full_moves_correctly() {

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1209,11 +1209,9 @@ mod cache_allocate_object_test {
         ),
     );
 
-    #[test]
-    fn slabs_partial_becomes_non_null_slabs_partial_is_non_null() {
+    fn test_slabs_partial_becomes_non_null_slabs_partial_is_non_null<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains two empty slabs.
-        type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
@@ -1288,6 +1286,22 @@ mod cache_allocate_object_test {
             );
         }
     }
+
+    test_against_types!(
+        test_slabs_partial_becomes_non_null_slabs_partial_is_non_null,
+        (
+            slabs_partial_becomes_non_null_slabs_partial_is_non_null_for_type1,
+            Type1
+        ),
+        (
+            slabs_partial_becomes_non_null_slabs_partial_is_non_null_for_type2,
+            Type2
+        ),
+        (
+            slabs_partial_becomes_non_null_slabs_partial_is_non_null_for_type3,
+            Type3
+        ),
+    );
 
     #[test]
     fn slabs_partial_becomes_null_slabs_partial_is_null() {

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -749,7 +749,7 @@ mod test_marcos {
     /// `test_panic_against_types` generates the "should_panic" tests against the given types
     /// for a generic test method.
     ///
-    /// # Example:
+    /// # Example
     /// ```//noinspection
     /// test_panic_against_types!(
     ///     my_generic_test_method,
@@ -774,7 +774,7 @@ mod test_marcos {
 
     /// `test_against_types` generates the tests against the given types for a generic test method.
     ///
-    /// # Example:
+    /// # Example
     /// ```//noinspection
     /// test_against_types!(
     ///     my_generic_test_method,
@@ -791,6 +791,29 @@ mod test_marcos {
                     $test::<$t>()
                 }
 
+            )+
+        };
+    }
+
+    /// `test_against_types_arguments` generates the tests against the given types and arguments
+    /// for a generic test method.
+    ///
+    /// # Example
+    /// ```//noinspection
+    /// test_against_types_arguments!(
+    ///     my_generic_test_method,
+    ///     (name_for_the_generated_test1, Type1, arg1, arg2),
+    ///     (name_for_the_generated_test2, Type2, arg1, arg2),
+    ///     (name_for_the_generated_test3, Type3, arg1, arg2),
+    /// );
+    /// ```
+    macro_rules! test_against_types_arguments {
+        ($test:ident, $(($fn_name:tt, $t:ty, $($args:expr), *)), +,) => {
+            $(
+                #[test]
+                fn $fn_name() {
+                    $test::<$t>($($args), *);
+                }
             )+
         };
     }

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1865,7 +1865,6 @@ mod cache_allocate_object_test {
     fn test_general_case<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains three empty slabs, three partial slabs and two full slabs.
-        type T = TestObject;
         let name = ['c'; CACHE_NAME_LENGTH];
         let layout = safe_slab_layout::<T>(4);
 

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -3977,6 +3977,7 @@ mod test_utils {
     use alloc::alloc::{alloc, dealloc};
     use alloc::vec::Vec;
     use core::alloc::Layout;
+    use core::cmp::max;
     use core::ptr::{NonNull, null_mut};
 
     #[derive(Debug, PartialEq)]
@@ -4294,10 +4295,24 @@ mod test_utils {
         Layout::from_size_align(size, align).expect("Failed to create layout")
     }
 
-    /// `safe_slab_size` assumes the slot size is equal to the size of `T` and
-    /// returns a slab size that can accommodate `total_slots`.
+    /// `safe_slab_size` returns a slab size that can accommodate `total_slots`.
+    /// It assumes the slot size is equal to the size of `T`.
+    ///
+    /// Please be aware that the size returned may lead to an actual `total_slots`
+    /// larger than the given value.
+    ///
+    /// # Panics
+    /// This function will panic if `total_slots` is zero.
     pub fn safe_slab_size<T: Default>(total_slots: usize) -> ByteSize {
-        size_of::<SlabHeader<T>>() + align_of::<T>() + size_of::<T>() * total_slots
+        assert!(
+            total_slots > 0,
+            "The total_slots should be greater than zero"
+        );
+
+        max(
+            Cache::<T>::min_slab_size(),
+            size_of::<SlabHeader<T>>() + align_of::<T>() + size_of::<T>() * total_slots,
+        )
     }
 
     /// Verify if the `cache` satisfies the invariants of a [Cache].

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1495,7 +1495,7 @@ mod cache_allocate_object_test {
         let result = unsafe { Cache::allocate_object(&raw mut cache) };
         assert!(result.is_ok(), "The result should be Ok but got {result:?}");
 
-        // Assert:
+        // Assert
         let allocated_object = result.unwrap();
         assert!(
             allocated_object.source == empty_slab1 || allocated_object.source == empty_slab2,
@@ -3992,7 +3992,11 @@ mod test_utils {
         expected_slabs: &Vec<*mut u8>,
         expected_objects: &Vec<SlabObject<T>>,
     ) {
-        verify_cache_name(cache, expected_name, "The cache name doesn't match the expected");
+        verify_cache_name(
+            cache,
+            expected_name,
+            "The cache name doesn't match the expected",
+        );
 
         verify_cache_type(cache);
         verify_cache_slab_layout(cache, expected_layout);
@@ -4276,7 +4280,10 @@ mod test_utils {
         expected_slabs: &Vec<*mut u8>,
         err_message: &str,
     ) {
-        let mut expected_addrs = expected_slabs.iter().map(|&slab| slab.addr()).collect::<Vec<_>>();
+        let mut expected_addrs = expected_slabs
+            .iter()
+            .map(|&slab| slab.addr())
+            .collect::<Vec<_>>();
         expected_addrs.sort();
 
         let mut actual_addrs = cache_slabs::<T>(cache)

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -4166,6 +4166,25 @@ mod test_utils {
         }
     }
 
+    /// `prepend_new_empty_slab` prepends an empty slab to the `slabs_empty` of the `cache`.
+    /// This empty slab is acquired from the `slab_man`.
+    ///
+    /// # Safety
+    /// * `cache` must be a valid pointer and in a valid state.
+    /// * `cache` and `slab_man` must have a compatible slab layout.
+    pub unsafe fn prepend_new_empty_slab<T: Default>(
+        cache: *mut Cache<T>,
+        slab_man: &mut SlabMan<T>,
+    ) {
+        let new_slab = slab_man.new_test_slab(cache);
+
+        if !(*cache).slabs_empty.is_null() {
+            (*new_slab).next = (*cache).slabs_empty;
+            (*(*cache).slabs_empty).prev = new_slab;
+        }
+        (*cache).slabs_empty = new_slab;
+    }
+
     /// `prepend_new_full_slab` prepends a full slab to the `slabs_full` of the `cache`.
     /// This full slab is acquired from the `slab_man`, and all its allocated objects are
     /// appended to the `slab_objects`.

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1477,7 +1477,6 @@ mod cache_allocate_object_test {
             unsafe { (*empty_slab1).total_slots > 1 },
             "The empty slabs should have more than one free slot to ensure a partial slab after the allocation"
         );
-
         assert_eq!(
             null_mut(),
             cache.slabs_partial,

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1398,11 +1398,9 @@ mod cache_allocate_object_test {
         ),
     );
 
-    #[test]
-    fn slabs_full_becomes_non_null_slabs_full_is_non_null() {
+    fn test_slabs_full_becomes_non_null_slabs_full_is_non_null<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains a partial slab that is one free slot left.
-        type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
@@ -1462,6 +1460,22 @@ mod cache_allocate_object_test {
             );
         }
     }
+
+    test_against_types!(
+        test_slabs_full_becomes_non_null_slabs_full_is_non_null,
+        (
+            slabs_full_becomes_non_null_slabs_full_is_non_null_for_type1,
+            Type1
+        ),
+        (
+            slabs_full_becomes_non_null_slabs_full_is_non_null_for_type2,
+            Type2
+        ),
+        (
+            slabs_full_becomes_non_null_slabs_full_is_non_null_for_type3,
+            Type3
+        ),
+    );
 
     #[test]
     fn an_empty_slab_becomes_partial_moves_correctly() {

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1477,11 +1477,9 @@ mod cache_allocate_object_test {
         ),
     );
 
-    #[test]
-    fn an_empty_slab_becomes_partial_moves_correctly() {
+    fn test_an_empty_slab_becomes_partial_moves_correctly<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains two empty slabs and a full slab.
-        type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
@@ -1566,6 +1564,22 @@ mod cache_allocate_object_test {
             );
         }
     }
+
+    test_against_types!(
+        test_an_empty_slab_becomes_partial_moves_correctly,
+        (
+            an_empty_slab_becomes_partial_moves_correctly_for_type1,
+            Type1
+        ),
+        (
+            an_empty_slab_becomes_partial_moves_correctly_for_type2,
+            Type2
+        ),
+        (
+            an_empty_slab_becomes_partial_moves_correctly_for_type3,
+            Type3
+        ),
+    );
 
     #[test]
     fn an_empty_slab_becomes_full_moves_correctly() {

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1581,12 +1581,10 @@ mod cache_allocate_object_test {
         ),
     );
 
-    #[test]
-    fn an_empty_slab_becomes_full_moves_correctly() {
+    fn test_an_empty_slab_becomes_full_moves_correctly<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains two empty slabs and a full slab.
         // All slabs have a total_slots of one.
-        type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(1), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
@@ -1675,6 +1673,12 @@ mod cache_allocate_object_test {
             );
         }
     }
+
+    test_against_types!(
+        test_an_empty_slab_becomes_full_moves_correctly,
+        (an_empty_slab_becomes_full_moves_correctly_for_type1, Type1),
+        (an_empty_slab_becomes_full_moves_correctly_for_type2, Type2),
+    );
 
     #[test]
     fn a_partial_slab_remains_partial_no_move() {

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1863,8 +1863,7 @@ mod cache_allocate_object_test {
         (a_partial_slab_becomes_full_moves_correctly_for_type3, Type3),
     );
 
-    #[test]
-    fn general_case_holds_cache_invariants() {
+    fn test_general_case_holds_cache_invariants<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains two empty slabs, two partial slabs and two full slabs.
         type T = TestObject;
@@ -1933,6 +1932,13 @@ mod cache_allocate_object_test {
             );
         }
     }
+
+    test_against_types!(
+        test_general_case_holds_cache_invariants,
+        (general_case_holds_cache_invariants_for_type1, Type1),
+        (general_case_holds_cache_invariants_for_type2, Type2),
+        (general_case_holds_cache_invariants_for_type3, Type3),
+    );
 }
 
 #[cfg(test)]

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1414,6 +1414,11 @@ mod cache_allocate_object_test {
             cache.slabs_partial,
             "The slabs_partial should be null initially to ensure the object is allocated from the empty slab"
         );
+        assert_ne!(
+            null_mut(),
+            cache.slabs_empty,
+            "The slabs_empty should not be null initially"
+        );
 
         // Act
         let result = unsafe { Cache::allocate_object(&raw mut cache) };

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1218,6 +1218,102 @@ mod cache_allocate_object_test {
         (returned_object_has_default_value_for_type3, Type3),
     );
 
+    fn test_returned_object_has_correct_source_for_empty<T: Default + Debug>() {
+        // Arrange:
+        // Create a cache that contains one empty slab and two full slabs.
+        let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
+            .expect("Failed to create layout");
+        let name = ['c'; CACHE_NAME_LENGTH];
+
+        let mut cache = Cache::<T>::new(name, layout);
+        let mut slab_man = SlabMan::<T>::new(layout);
+        let mut slab_objects = Vec::new();
+
+        unsafe {
+            prepend_new_slabs(
+                &raw mut cache,
+                &mut slab_man,
+                &mut slab_objects,
+                2,
+                &Vec::new(),
+                1,
+            );
+        }
+        let empty_slab = cache.slabs_empty;
+
+        assert_eq!(
+            null_mut(),
+            cache.slabs_partial,
+            "The slabs_partial should be null initially to ensure the object is allocated from the empty slab"
+        );
+
+        // Act
+        let result = unsafe { Cache::allocate_object(&raw mut cache) };
+        assert!(result.is_ok(), "The result should be Ok but got {result:?}");
+
+        // Assert
+        let allocated_object = result.unwrap();
+        assert_eq!(
+            empty_slab, allocated_object.source,
+            "The allocated object should come from the empty_slab"
+        );
+    }
+
+    test_against_types!(
+        test_returned_object_has_correct_source_for_empty,
+        (returned_object_has_correct_source_for_empty_type1, Type1),
+        (returned_object_has_correct_source_for_empty_type2, Type2),
+        (returned_object_has_correct_source_for_empty_type3, Type3),
+    );
+
+    fn test_returned_object_has_correct_source_for_partial<T: Default + Debug>() {
+        // Arrange:
+        // Create a cache that contains one partial slab and two full slabs.
+        let layout = Layout::from_size_align(safe_slab_size::<T>(4), align_of::<SlabHeader<T>>())
+            .expect("Failed to create layout");
+        let name = ['c'; CACHE_NAME_LENGTH];
+
+        let mut cache = Cache::<T>::new(name, layout);
+        let mut slab_man = SlabMan::<T>::new(layout);
+        let mut slab_objects = Vec::new();
+
+        unsafe {
+            prepend_new_slabs(
+                &raw mut cache,
+                &mut slab_man,
+                &mut slab_objects,
+                2,
+                &vec![2],
+                0,
+            );
+        }
+        let partial_slab = cache.slabs_partial;
+
+        assert_eq!(
+            null_mut(),
+            cache.slabs_empty,
+            "The slabs_empty should be null initially to ensure the object is allocated from the partial slab"
+        );
+
+        // Act
+        let result = unsafe { Cache::allocate_object(&raw mut cache) };
+        assert!(result.is_ok(), "The result should be Ok but got {result:?}");
+
+        // Assert
+        let allocated_object = result.unwrap();
+        assert_eq!(
+            partial_slab, allocated_object.source,
+            "The allocated object should come from the empty_slab"
+        );
+    }
+
+    test_against_types!(
+        test_returned_object_has_correct_source_for_partial,
+        (returned_object_has_correct_sorce_for_partial_type1, Type1),
+        (returned_object_has_correct_sorce_for_partial_type2, Type2),
+        (returned_object_has_correct_sorce_for_partial_type3, Type3),
+    );
+
     fn test_slabs_empty_becomes_null<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains a single empty slab.

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1053,11 +1053,9 @@ mod cache_allocate_object_test {
         ),
     );
 
-    #[test]
-    fn full_slabs_only_returns_no_slab_available_err_cache_unmodified() {
+    fn test_full_slabs_only_returns_no_slab_available_err_cache_unmodified<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains only two full slabs.
-        type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
@@ -1130,6 +1128,22 @@ mod cache_allocate_object_test {
             );
         }
     }
+
+    test_against_types!(
+        test_full_slabs_only_returns_no_slab_available_err_cache_unmodified,
+        (
+            full_slabs_only_returns_no_slab_available_err_cache_unmodified_for_type1,
+            Type1
+        ),
+        (
+            full_slabs_only_returns_no_slab_available_err_cache_unmodified_for_type2,
+            Type2
+        ),
+        (
+            full_slabs_only_returns_no_slab_available_err_cache_unmodified_for_type3,
+            Type3
+        ),
+    );
 
     #[test]
     fn slabs_empty_becomes_null_slabs_empty_is_null() {

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -744,6 +744,59 @@ pub enum Error {
 }
 
 #[cfg(test)]
+#[macro_use]
+mod test_marcos {
+    /// `test_panic_against_types` generates the "should_panic" tests against the given types
+    /// for a generic test method.
+    ///
+    /// # Example:
+    /// ```//noinspection
+    /// test_panic_against_types!(
+    ///     my_generic_test_method,
+    ///     the_expected_panic_message,
+    ///     (name_for_the_generated_test_for_type1, Type1),
+    ///     (name_for_the_generated_test_for_type2, Type2),
+    ///     (name_for_the_generated_test_for_type3, Type3),
+    /// );
+    /// ```
+    macro_rules! test_panic_against_types {
+        ($test:ident, $panic_msg:literal, $(($fn_name:tt, $t:ty)), +,) => {
+            $(
+                #[test]
+                #[should_panic(expected = $panic_msg)]
+                fn $fn_name() {
+                    $test::<$t>()
+                }
+
+            )+
+        };
+    }
+
+    /// `test_against_types` generates the tests against the given types for a generic test method.
+    ///
+    /// # Example:
+    /// ```//noinspection
+    /// test_against_types!(
+    ///     my_generic_test_method,
+    ///     (name_for_the_generated_test_for_type1, Type1),
+    ///     (name_for_the_generated_test_for_type2, Type2),
+    ///     (name_for_the_generated_test_for_type3, Type3),
+    /// );
+    /// ```
+    macro_rules! test_against_types {
+        ($test:ident, $(($fn_name:tt, $t:ty)), +,) => {
+            $(
+                #[test]
+                fn $fn_name() {
+                    $test::<$t>()
+                }
+
+            )+
+        };
+    }
+}
+
+#[cfg(test)]
 mod cache_new_test {
     use crate::mem::slab::test_utils::{
         TestObject, cache_slabs, safe_slab_size, verify_cache_invariants,
@@ -929,31 +982,6 @@ mod cache_allocate_object_test {
     type Type1 = TestObject;
     type Type2 = TestObject2;
     type Type3 = u8;
-
-    macro_rules! test_panic_against_types {
-        ($test:ident, $panic_msg:literal, $(($fn_name:tt, $t:ty)), +,) => {
-            $(
-                #[test]
-                #[should_panic(expected = $panic_msg)]
-                fn $fn_name() {
-                    $test::<$t>()
-                }
-
-            )+
-        };
-    }
-
-    macro_rules! test_against_types {
-        ($test:ident, $(($fn_name:tt, $t:ty)), +,) => {
-            $(
-                #[test]
-                fn $fn_name() {
-                    $test::<$t>()
-                }
-
-            )+
-        };
-    }
 
     fn test_null_cache_panics<T: Default>() {
         let _ = unsafe { Cache::<T>::allocate_object(null_mut()) };

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1760,12 +1760,10 @@ mod cache_allocate_object_test {
         (a_partial_slab_remains_partial_no_move_for_type3, Type3),
     );
 
-    #[test]
-    fn a_partial_slab_becomes_full_moves_correctly() {
+    fn test_a_partial_slab_becomes_full_moves_correctly<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains two partial slabs and one full slab.
         // Both partial slabs have only one slot available.
-        type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
@@ -1857,6 +1855,13 @@ mod cache_allocate_object_test {
             );
         }
     }
+
+    test_against_types!(
+        test_a_partial_slab_becomes_full_moves_correctly,
+        (a_partial_slab_becomes_full_moves_correctly_for_type1, Type1),
+        (a_partial_slab_becomes_full_moves_correctly_for_type2, Type2),
+        (a_partial_slab_becomes_full_moves_correctly_for_type3, Type3),
+    );
 
     #[test]
     fn general_case_holds_cache_invariants() {

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -4210,10 +4210,7 @@ mod test_utils {
     /// # Safety
     /// * `cache` must be a valid pointer and in a valid state.
     /// * `cache` and `slab_man` must have a compatible slab layout.
-    unsafe fn prepend_new_empty_slab<T: Default>(
-        cache: *mut Cache<T>,
-        slab_man: &mut SlabMan<T>,
-    ) {
+    unsafe fn prepend_new_empty_slab<T: Default>(cache: *mut Cache<T>, slab_man: &mut SlabMan<T>) {
         let new_slab = slab_man.new_test_slab(cache);
 
         if !(*cache).slabs_empty.is_null() {
@@ -4287,6 +4284,27 @@ mod test_utils {
             (*(*cache).slabs_full).prev = new_slab;
         }
         (*cache).slabs_full = new_slab;
+    }
+
+    /// `safe_slab_layout` returns a layout that complies with the slab alignment and
+    /// can accommodate `total_slots`. It assumes the slot size is equal to the size of `T`.
+    ///
+    /// Please be aware that the size returned may lead to an actual `total_slots`
+    /// larger than the given value.
+    ///
+    /// # Panics
+    /// This function will panic when
+    /// * The `total_slots` is zero.
+    /// * The resulting size overflows isize.
+    pub fn safe_slab_layout<T: Default>(total_slots: usize) -> Layout {
+        assert!(
+            total_slots > 0,
+            "The total_slots should be greater than zero"
+        );
+
+        let size = safe_slab_size::<T>(total_slots);
+        let align = Cache::<T>::align_of_slab();
+        Layout::from_size_align(size, align).expect("Failed to create layout")
     }
 
     /// `safe_slab_size` assumes the slot size is equal to the size of `T` and

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -971,8 +971,8 @@ mod cache_allocate_object_test {
 
     use crate::mem::slab::Error::NoSlabAvailable;
     use crate::mem::slab::test_utils::{
-        SlabMan, TestObject, TestObject2, contains_node, prepend_new_slabs, safe_slab_size,
-        size_of_list, verify_cache_invariants_v2,
+        SlabMan, TestObject, TestObject2, contains_node, prepend_new_slabs, safe_slab_layout,
+        safe_slab_size, size_of_list, verify_cache_invariants_v2,
     };
     use crate::mem::slab::{CACHE_NAME_LENGTH, Cache, SlabHeader};
     use alloc::vec;
@@ -1000,9 +1000,8 @@ mod cache_allocate_object_test {
     fn test_no_slabs_returns_no_slab_available_err_cache_unmodified<T: Default + Debug>() {
         // Arrange:
         // Create a cache with no slabs.
-        let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-            .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
+        let layout = safe_slab_layout::<T>(2);
 
         let mut cache = Cache::<T>::new(name, layout);
         let slab_man = SlabMan::<T>::new(layout);
@@ -1086,9 +1085,8 @@ mod cache_allocate_object_test {
     fn test_full_slabs_only_returns_no_slab_available_err_cache_unmodified<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains only two full slabs.
-        let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-            .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
+        let layout = safe_slab_layout::<T>(2);
 
         let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
@@ -1173,9 +1171,8 @@ mod cache_allocate_object_test {
     fn test_returned_object_has_default_value<T: Default + Debug + PartialEq>() {
         // Arrange:
         // Create a cache that contains a single empty slab.
-        let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-            .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
+        let layout = safe_slab_layout::<T>(2);
 
         let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
@@ -1221,9 +1218,8 @@ mod cache_allocate_object_test {
     fn test_returned_object_has_correct_source_for_empty<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains one empty slab and two full slabs.
-        let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-            .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
+        let layout = safe_slab_layout::<T>(2);
 
         let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
@@ -1317,9 +1313,8 @@ mod cache_allocate_object_test {
     fn test_slabs_empty_becomes_null<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains a single empty slab.
-        let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-            .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
+        let layout = safe_slab_layout::<T>(2);
 
         let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
@@ -1375,9 +1370,8 @@ mod cache_allocate_object_test {
     fn test_slabs_partial_becomes_non_null<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains two empty slabs.
-        let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-            .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
+        let layout = safe_slab_layout::<T>(2);
 
         let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
@@ -1461,9 +1455,8 @@ mod cache_allocate_object_test {
         // Arrange:
         // create a cache that contains a partial slab that is one free slot left and
         // a full slab.
-        let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-            .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
+        let layout = safe_slab_layout::<T>(2);
 
         let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
@@ -1533,9 +1526,8 @@ mod cache_allocate_object_test {
     fn test_slabs_full_becomes_non_null<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains a partial slab that is one free slot left.
-        let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-            .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
+        let layout = safe_slab_layout::<T>(2);
 
         let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
@@ -1600,9 +1592,8 @@ mod cache_allocate_object_test {
     fn test_empty_slab_becomes_partial<T: Default + Debug>() {
         // Arrange:
         // Create a cache that contains two empty slabs and a full slab.
-        let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-            .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
+        let layout = safe_slab_layout::<T>(2);
 
         let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
@@ -1685,9 +1676,8 @@ mod cache_allocate_object_test {
         // Arrange:
         // Create a cache that contains two empty slabs and a full slab.
         // All slabs have a total_slots of one.
-        let layout = Layout::from_size_align(safe_slab_size::<T>(1), align_of::<SlabHeader<T>>())
-            .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
+        let layout = safe_slab_layout::<T>(1);
 
         let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
@@ -1775,9 +1765,8 @@ mod cache_allocate_object_test {
         // Arrange:
         // Create a cache that contains two partial slabs.
         // Both partial slabs have more than one available slot.
-        let layout = Layout::from_size_align(safe_slab_size::<T>(4), align_of::<SlabHeader<T>>())
-            .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
+        let layout = safe_slab_layout::<T>(4);
 
         let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
@@ -1846,9 +1835,8 @@ mod cache_allocate_object_test {
         // Arrange:
         // Create a cache that contains two partial slabs and one full slab.
         // Both partial slabs have only one slot available.
-        let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-            .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
+        let layout = safe_slab_layout::<T>(2);
 
         let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);
@@ -1932,9 +1920,8 @@ mod cache_allocate_object_test {
         // Arrange:
         // Create a cache that contains three empty slabs, three partial slabs and two full slabs.
         type T = TestObject;
-        let layout = Layout::from_size_align(safe_slab_size::<T>(4), align_of::<SlabHeader<T>>())
-            .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
+        let layout = safe_slab_layout::<T>(4);
 
         let mut cache = Cache::<T>::new(name, layout);
         let mut slab_man = SlabMan::<T>::new(layout);

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -1303,12 +1303,10 @@ mod cache_allocate_object_test {
         ),
     );
 
-    #[test]
-    fn slabs_partial_becomes_null_slabs_partial_is_null() {
+    fn test_slabs_partial_becomes_null_slabs_partial_is_null<T: Default + Debug>() {
         // Arrange:
         // create a cache that contains a partial slab that is one free slot left and
         // a full slab.
-        type T = TestObject;
         let layout = Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
             .expect("Failed to create layout");
         let name = ['c'; CACHE_NAME_LENGTH];
@@ -1383,6 +1381,22 @@ mod cache_allocate_object_test {
             );
         }
     }
+
+    test_against_types!(
+        test_slabs_partial_becomes_null_slabs_partial_is_null,
+        (
+            slabs_partial_becomes_null_slabs_partial_is_null_for_type1,
+            Type1
+        ),
+        (
+            slabs_partial_becomes_null_slabs_partial_is_null_for_type2,
+            Type2
+        ),
+        (
+            slabs_partial_becomes_null_slabs_partial_is_null_for_type3,
+            Type3
+        ),
+    );
 
     #[test]
     fn slabs_full_becomes_non_null_slabs_full_is_non_null() {


### PR DESCRIPTION
This PR, following #12, continues to improve the tests for Cache::allocate_object. The major improvements are:

- Expanded tests for different types.
- Added tests verifying that the returned object has the default value.
- Added tests verifying that the returned object has the correct source.
- Added more general-case tests.
- Removed assertions that verify the general after-state of the cache and relied on verify_cache_invariants_v2 to cover it.
- Renamed tests to improve readability.
- Refactored tests with new test utilities to enhance clarity.

As before, we need to deprecate verify_cache_invariants as the review progresses. Additionally, there are currently almost no tests written for the test utils. I wonder if I can rely on my manual review instead of writing tests for them, which seems to involve a lot of work.