### PR TITLE
kernel::mem::slab: Refactor Cache::push_front

### DIFF
--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -2085,37 +2085,28 @@ mod cache_pop_front_test {
 }
 
 #[cfg(test)]
-mod cache_tests {
+mod cache_push_front_test {
     extern crate alloc;
-    use super::*;
-    use alloc::vec;
-    use alloc::vec::Vec;
-    use test_utils::*;
 
-    fn new_test_default<T: Default>() -> Cache<T> {
-        Cache::<T> {
-            name: ['c'; CACHE_NAME_LENGTH],
-            slab_layout: Layout::from_size_align(
-                safe_slab_size::<T>(2),
-                align_of::<SlabHeader<T>>(),
-            )
-            .expect("Failed to create the `slab_layout`"),
-            slabs_full: null_mut(),
-            slabs_partial: null_mut(),
-            slabs_empty: null_mut(),
-        }
-    }
+    use crate::mem::slab::test_utils::{
+        SlabMan, collect_list_slabs, create_slab_list, safe_slab_size, size_of_list,
+        verify_list_doubly_linked,
+    };
+    use crate::mem::slab::{Cache, SlabHeader};
+    use alloc::vec;
+    use core::alloc::Layout;
+    use core::ptr::null_mut;
 
     #[test]
     #[should_panic(expected = "Cache::push_front: node should not be null")]
-    fn push_front_null_head_and_node_panics() {
+    fn null_head_null_node_panics() {
         type T = u8;
         let _ = unsafe { Cache::<T>::push_front(null_mut(), null_mut()) };
     }
 
     #[test]
     #[should_panic(expected = "Cache::push_front: node should not be null")]
-    fn push_front_valid_head_null_node_panics() {
+    fn valid_head_null_node_panics() {
         // Create a head containing two nodes
         type T = u8;
         let slab_layout =
@@ -2131,7 +2122,7 @@ mod cache_tests {
 
     #[test]
     #[should_panic(expected = "Cache::push_front: head should not have its prev linked")]
-    fn push_front_prev_linked_head_panics() {
+    fn head_has_prev_linked_panics() {
         // Create a head with its prev linked
         type T = u8;
         let slab_layout =
@@ -2151,7 +2142,7 @@ mod cache_tests {
 
     #[test]
     #[should_panic(expected = "Cache::push_front: node should not have its prev linked")]
-    fn push_front_prev_linked_node_panics() {
+    fn node_has_prev_linked_panics() {
         // Create a node with its prev linked
         type T = u8;
         let slab_layout =
@@ -2168,7 +2159,7 @@ mod cache_tests {
 
     #[test]
     #[should_panic(expected = "Cache::push_front: node should not have its next linked")]
-    fn push_front_next_linked_node_panics() {
+    fn node_has_next_linked_panics() {
         // Create a node with its next linked
         type T = u8;
         let slab_layout =
@@ -2183,7 +2174,7 @@ mod cache_tests {
     }
 
     #[test]
-    fn push_front_null_head_valid_node_return_node() {
+    fn null_head_valid_node_returns_node() {
         // Create the node to be inserted
         type T = u8;
         let slab_layout =
@@ -2207,7 +2198,7 @@ mod cache_tests {
     }
 
     #[test]
-    fn push_front_valid_head_and_node_return_node() {
+    fn valid_head_valid_node_returns_node() {
         // Create a head containing two nodes
         type T = u8;
         let slab_layout =
@@ -2237,6 +2228,29 @@ mod cache_tests {
         );
 
         unsafe { verify_list_doubly_linked(new_head) };
+    }
+}
+
+#[cfg(test)]
+mod cache_tests {
+    extern crate alloc;
+    use super::*;
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use test_utils::*;
+
+    fn new_test_default<T: Default>() -> Cache<T> {
+        Cache::<T> {
+            name: ['c'; CACHE_NAME_LENGTH],
+            slab_layout: Layout::from_size_align(
+                safe_slab_size::<T>(2),
+                align_of::<SlabHeader<T>>(),
+            )
+            .expect("Failed to create the `slab_layout`"),
+            slabs_full: null_mut(),
+            slabs_partial: null_mut(),
+            slabs_empty: null_mut(),
+        }
     }
 
     #[test]

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -2107,97 +2107,94 @@ mod cache_push_front_test {
     #[test]
     #[should_panic(expected = "Cache::push_front: node should not be null")]
     fn valid_head_null_node_panics() {
+        // Arrange:
         // Create a head containing two nodes
         let layout = safe_slab_layout::<T>(2);
         let mut slab_man = SlabMan::new(layout);
-
         let head = create_slab_list(&mut slab_man, 2);
 
-        // Exercise push_front
+        // Act
         let _ = unsafe { Cache::<T>::push_front(head, null_mut()) };
     }
 
     #[test]
     #[should_panic(expected = "Cache::push_front: head should not have its prev linked")]
     fn head_has_prev_linked_panics() {
-        // Create a head with its prev linked
+        // Arrange:
+        // Create a head with its prev linked and a node to be pushed.
         let layout = safe_slab_layout::<T>(2);
         let mut slab_man = SlabMan::<T>::new(layout);
-
         let prev = create_slab_list(&mut slab_man, 2);
         let head = unsafe { (*prev).next };
-
-        // Create the node to be inserted
         let node = slab_man.new_test_slab(null_mut());
 
-        // Exercise push_front
+        // Act
         unsafe { Cache::push_front(head, node) };
     }
 
     #[test]
     #[should_panic(expected = "Cache::push_front: node should not have its prev linked")]
     fn node_has_prev_linked_panics() {
-        // Create a node with its prev linked
+        // Arrange:
+        // Create a node with its prev linked.
         let layout = safe_slab_layout::<T>(2);
         let mut slab_man = SlabMan::<T>::new(layout);
-
         let prev = create_slab_list(&mut slab_man, 2);
         let node = unsafe { (*prev).next };
 
-        // Exercise push_front
+        // Act
         unsafe { Cache::push_front(null_mut(), node) };
     }
 
     #[test]
     #[should_panic(expected = "Cache::push_front: node should not have its next linked")]
     fn node_has_next_linked_panics() {
-        // Create a node with its next linked
+        // Arrange:
+        // Create a node with its next linked.
         let layout = safe_slab_layout::<T>(2);
         let mut slab_man = SlabMan::<T>::new(layout);
-
         let node = create_slab_list(&mut slab_man, 2);
 
-        // Exercise push_front
+        // Act
         unsafe { Cache::push_front(null_mut(), node) };
     }
 
     #[test]
     fn null_head_valid_node_returns_node() {
-        // Create the node to be inserted
+        // Arrange:
+        // Create the node to be inserted.
         let layout = safe_slab_layout::<T>(2);
         let mut slab_man = SlabMan::<T>::new(layout);
-
         let node = slab_man.new_test_slab(null_mut());
 
-        // Exercise push_front
+        // Act
         let new_head = unsafe { Cache::push_front(null_mut(), node) };
 
-        // Verify the new head
+        // Assert
         assert_eq!(node, new_head, "The new head should be the node");
         assert_eq!(
             1,
             unsafe { size_of_list(new_head) },
             "The new head should contain one node"
         );
+
         unsafe { verify_list_doubly_linked(new_head) };
     }
 
     #[test]
     fn valid_head_valid_node_returns_node() {
-        // Create a head containing two nodes
+        // Arrange:
+        // Create a head containing two nodes and a node to be inserted.
         let layout = safe_slab_layout::<T>(2);
         let mut slab_man = SlabMan::<T>::new(layout);
-
         let head = create_slab_list(&mut slab_man, 2);
         let next = unsafe { (*head).next };
-
-        // Create the node to be inserted
         let node = slab_man.new_test_slab(null_mut());
 
-        // Exercise push_front
+        // Act
         let new_head = unsafe { Cache::push_front(head, node) };
 
-        // Verify the new head
+        // Assert
         assert_eq!(node, new_head, "The new head should be the node");
 
         let mut expected_list_nodes = vec![new_head, head, next];

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -2182,7 +2182,7 @@ mod cache_push_front_test {
     }
 
     #[test]
-    fn valid_head_valid_node_returns_node() {
+    fn valid_head_valid_node_returns_node_preserve_order() {
         // Arrange:
         // Create a head containing two nodes and a node to be inserted.
         let layout = safe_slab_layout::<T>(2);
@@ -2196,14 +2196,10 @@ mod cache_push_front_test {
 
         // Assert
         assert_eq!(node, new_head, "The new head should be the node");
-
-        let mut expected_list_nodes = vec![new_head, head, next];
-        expected_list_nodes.sort();
-        let mut actual_list_nodes = unsafe { collect_list_slabs(node) };
-        actual_list_nodes.sort();
         assert_eq!(
-            expected_list_nodes, actual_list_nodes,
-            "The new head should contain the expected nodes"
+            vec![new_head, head, next],
+            unsafe { collect_list_slabs(node) },
+            "The new head should contain the expected nodes in the correct order"
         );
 
         unsafe { verify_list_doubly_linked(new_head) };

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -2088,13 +2088,12 @@ mod cache_pop_front_test {
 mod cache_push_front_test {
     extern crate alloc;
 
+    use crate::mem::slab::Cache;
     use crate::mem::slab::test_utils::{
-        SlabMan, collect_list_slabs, create_slab_list, safe_slab_size, size_of_list,
+        SlabMan, collect_list_slabs, create_slab_list, safe_slab_layout, size_of_list,
         verify_list_doubly_linked,
     };
-    use crate::mem::slab::{Cache, SlabHeader};
     use alloc::vec;
-    use core::alloc::Layout;
     use core::ptr::null_mut;
 
     type T = u8;
@@ -2109,10 +2108,8 @@ mod cache_push_front_test {
     #[should_panic(expected = "Cache::push_front: node should not be null")]
     fn valid_head_null_node_panics() {
         // Create a head containing two nodes
-        let slab_layout =
-            Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-                .expect("Failed to create slab_layout");
-        let mut slab_man = SlabMan::new(slab_layout);
+        let layout = safe_slab_layout::<T>(2);
+        let mut slab_man = SlabMan::new(layout);
 
         let head = create_slab_list(&mut slab_man, 2);
 
@@ -2124,10 +2121,8 @@ mod cache_push_front_test {
     #[should_panic(expected = "Cache::push_front: head should not have its prev linked")]
     fn head_has_prev_linked_panics() {
         // Create a head with its prev linked
-        let slab_layout =
-            Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-                .expect("Failed to create slab_layout");
-        let mut slab_man = SlabMan::<T>::new(slab_layout);
+        let layout = safe_slab_layout::<T>(2);
+        let mut slab_man = SlabMan::<T>::new(layout);
 
         let prev = create_slab_list(&mut slab_man, 2);
         let head = unsafe { (*prev).next };
@@ -2143,10 +2138,8 @@ mod cache_push_front_test {
     #[should_panic(expected = "Cache::push_front: node should not have its prev linked")]
     fn node_has_prev_linked_panics() {
         // Create a node with its prev linked
-        let slab_layout =
-            Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-                .expect("Failed to create slab_layout");
-        let mut slab_man = SlabMan::<T>::new(slab_layout);
+        let layout = safe_slab_layout::<T>(2);
+        let mut slab_man = SlabMan::<T>::new(layout);
 
         let prev = create_slab_list(&mut slab_man, 2);
         let node = unsafe { (*prev).next };
@@ -2159,10 +2152,8 @@ mod cache_push_front_test {
     #[should_panic(expected = "Cache::push_front: node should not have its next linked")]
     fn node_has_next_linked_panics() {
         // Create a node with its next linked
-        let slab_layout =
-            Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-                .expect("Failed to create slab_layout");
-        let mut slab_man = SlabMan::<T>::new(slab_layout);
+        let layout = safe_slab_layout::<T>(2);
+        let mut slab_man = SlabMan::<T>::new(layout);
 
         let node = create_slab_list(&mut slab_man, 2);
 
@@ -2173,10 +2164,8 @@ mod cache_push_front_test {
     #[test]
     fn null_head_valid_node_returns_node() {
         // Create the node to be inserted
-        let slab_layout =
-            Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-                .expect("Failed to create slab_layout");
-        let mut slab_man = SlabMan::<T>::new(slab_layout);
+        let layout = safe_slab_layout::<T>(2);
+        let mut slab_man = SlabMan::<T>::new(layout);
 
         let node = slab_man.new_test_slab(null_mut());
 
@@ -2196,10 +2185,8 @@ mod cache_push_front_test {
     #[test]
     fn valid_head_valid_node_returns_node() {
         // Create a head containing two nodes
-        let slab_layout =
-            Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
-                .expect("Failed to create slab_layout");
-        let mut slab_man = SlabMan::<T>::new(slab_layout);
+        let layout = safe_slab_layout::<T>(2);
+        let mut slab_man = SlabMan::<T>::new(layout);
 
         let head = create_slab_list(&mut slab_man, 2);
         let next = unsafe { (*head).next };

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -191,7 +191,6 @@ where
         if node.is_null() {
             panic!("Cache::push_front: node should not be null")
         }
-
         assert_eq!(
             null_mut(),
             (*node).prev,
@@ -206,7 +205,6 @@ where
         if head.is_null() {
             return node;
         };
-
         assert_eq!(
             null_mut(),
             (*head).prev,

--- a/kernel/src/mem/slab.rs
+++ b/kernel/src/mem/slab.rs
@@ -2097,10 +2097,11 @@ mod cache_push_front_test {
     use core::alloc::Layout;
     use core::ptr::null_mut;
 
+    type T = u8;
+
     #[test]
     #[should_panic(expected = "Cache::push_front: node should not be null")]
     fn null_head_null_node_panics() {
-        type T = u8;
         let _ = unsafe { Cache::<T>::push_front(null_mut(), null_mut()) };
     }
 
@@ -2108,7 +2109,6 @@ mod cache_push_front_test {
     #[should_panic(expected = "Cache::push_front: node should not be null")]
     fn valid_head_null_node_panics() {
         // Create a head containing two nodes
-        type T = u8;
         let slab_layout =
             Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
                 .expect("Failed to create slab_layout");
@@ -2124,7 +2124,6 @@ mod cache_push_front_test {
     #[should_panic(expected = "Cache::push_front: head should not have its prev linked")]
     fn head_has_prev_linked_panics() {
         // Create a head with its prev linked
-        type T = u8;
         let slab_layout =
             Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
                 .expect("Failed to create slab_layout");
@@ -2144,7 +2143,6 @@ mod cache_push_front_test {
     #[should_panic(expected = "Cache::push_front: node should not have its prev linked")]
     fn node_has_prev_linked_panics() {
         // Create a node with its prev linked
-        type T = u8;
         let slab_layout =
             Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
                 .expect("Failed to create slab_layout");
@@ -2161,7 +2159,6 @@ mod cache_push_front_test {
     #[should_panic(expected = "Cache::push_front: node should not have its next linked")]
     fn node_has_next_linked_panics() {
         // Create a node with its next linked
-        type T = u8;
         let slab_layout =
             Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
                 .expect("Failed to create slab_layout");
@@ -2176,7 +2173,6 @@ mod cache_push_front_test {
     #[test]
     fn null_head_valid_node_returns_node() {
         // Create the node to be inserted
-        type T = u8;
         let slab_layout =
             Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
                 .expect("Failed to create slab_layout");
@@ -2200,7 +2196,6 @@ mod cache_push_front_test {
     #[test]
     fn valid_head_valid_node_returns_node() {
         // Create a head containing two nodes
-        type T = u8;
         let slab_layout =
             Layout::from_size_align(safe_slab_size::<T>(2), align_of::<SlabHeader<T>>())
                 .expect("Failed to create slab_layout");


### PR DESCRIPTION
This PR improves the existing implementation in the following aspects:

- Extracts tests to a separate module.
- Refactors tests with new test utils.
- Enhances test to verify that the returned head preserves the original node order.
- Improves readability.